### PR TITLE
Some changes for cleaning the sections after leaving a page.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Let's consider structure of simple "contact list" web application:
   
   <section id="contact-list" src="pages/contact-list.htm"></section>
   <section id="contact-details" src="pages/contact-details.htm"></section>
-  <section id="about" src="pages/about.htm"></section>
+  <section id="about" src="pages/about.htm" default></section>
 
 </body>
 ```

--- a/spapp.js
+++ b/spapp.js
@@ -30,8 +30,11 @@
     }
     if(currentPageName) { // "close" current page view
       $(document.body).removeClass(currentPageName); // remove old page class {
-      if($currentPage) 
+      if($currentPage) {
         $currentPage.trigger("page.hidden",currentPageName);
+        if($currentPage.attr('src'))
+            $currentPage.empty();
+      }
     }
     $(document.body).addClass(currentPageName = pageName); // set new page class
     if($currentPage = $page)

--- a/spapp.js
+++ b/spapp.js
@@ -24,7 +24,7 @@
       var that = $page.length > 0 ? $page[0] : null;
       var r = ph.call(that , param);
       if( typeof r == "function" ) { // it returns the function that's used for view rendering
-        if(!($page.attr("no-ctl-cache") == ""))
+        if(!$page.is("[no-ctl-cache]"))
             pageHandlers[pageName] = r;
         r.call(that, param); // call that rendering function
       }
@@ -33,7 +33,7 @@
       $(document.body).removeClass(currentPageName); // remove old page class {
       if($currentPage) {
         $currentPage.trigger("page.hidden",currentPageName);
-        if($currentPage.attr('src') && $currentPage.attr("no-ctl-cache"))
+        if($currentPage.attr('src') && $currentPage.is("[no-ctl-cache]"))
             $currentPage.empty();
       }
     }

--- a/spapp.js
+++ b/spapp.js
@@ -1,84 +1,80 @@
 /**
-* @author Andrew Fedoniouk <andrew@terrainformatica.com>
-* @name jQuery Single Page Application micro framework 
-* @license MIT
-* @purpose routing and dynamic content on single page web applications
-*/
+ * @author Andrew Fedoniouk <andrew@terrainformatica.com>
+ * @name jQuery Single Page Application micro framework
+ * @license MIT
+ * @purpose routing and dynamic content on single page web applications
+ */
 
 
 (function($,window){
 
-  var pageHandlers = {};
-  
-  var currentPageName = null;
-  var $currentPage = null;
-  
-  function show(pageName,param) {
-    var $page = $("section#" + pageName);
-    if( $page.length == 0 ) {
-      console.warn("section with id=%s not found!",pageName);
-      return;
-    }
-    var ph = pageHandlers[pageName];
-    if( ph ) { 
-      var that = $page.length > 0 ? $page[0] : null;
-      var r = ph.call(that , param);
-      if( typeof r == "function" ) { // it returns the function that's used for view rendering
-        pageHandlers[pageName] = r; 
-        r.call(that, param); // call that rendering function
-      }
-    }
-    if(currentPageName) { // "close" current page view
-      $(document.body).removeClass(currentPageName); // remove old page class {
-      if($currentPage) {
-        $currentPage.trigger("page.hidden",currentPageName);
-        if($currentPage.attr('src'))
-            $currentPage.empty();
-      }
-    }
-    $(document.body).addClass(currentPageName = pageName); // set new page class
-    if($currentPage = $page)
-      $currentPage.trigger("page.shown",currentPageName);
-  }  
+    var pageHandlers = {};
 
-  function app(pageName,param) {
-  
-    var $page = $(document.body).find("section#" + pageName);  
-    
-    var src = $page.attr("src");
-    if( src && $page.find(">:first-child").length == 0) { // it has src and is empty
-      $.get(src, "html")
-          .done(function(html){$page.html(html); show(pageName,param); })
-          .fail(function(){ alert("failed to get:" + src); });
-    } else
-      show(pageName,param);
-  }
-  
-  app.page = function(pageName, handler) {
-    pageHandlers[pageName] = handler;
-  }
-  
-  function onhashchange() 
-  {
-    var hash = location.hash || "#" + $("section[default]").attr('id');
+    var currentPageName = null;
+    var $currentPage = null;
 
-    var re = /#([-0-9A-Za-z]+)(\:(.+))?/;
-    var match = re.exec(hash);
-    hash = match[1];
-    var param = match[3];
-    app(hash,param);
-  }
-  
-  $(window).on("hashchange", onhashchange );
-  
-  window.app = app;
-  
-  $(onhashchange); // call it for the initialization
+    function show(pageName,param) {
+        var $page = $("section#" + pageName);
+        if( $page.length == 0 ) {
+            console.warn("section with id=%s not found!",pageName);
+            return;
+        }
+        var ph = pageHandlers[pageName];
+        if( ph ) {
+            var that = $page.length > 0 ? $page[0] : null;
+
+            var r = ph.call(that , param);
+            if( typeof r == "function" ) { // it returns the function that's used for view rendering
+                if(!($page.attr("no-ctl-cache") == ""))
+                    pageHandlers[pageName] = r;
+                r.call(that, param); // call that rendering function
+            }
+        }
+        if(currentPageName) { // "close" current page view
+            $(document.body).removeClass(currentPageName); // remove old page class {
+            if($currentPage) {
+                $currentPage.trigger("page.hidden",currentPageName);
+                if($currentPage.attr('src') && $currentPage.attr("no-ctl-cache"))
+                    $currentPage.empty();
+            }
+        }
+        $(document.body).addClass(currentPageName = pageName); // set new page class
+        if($currentPage = $page)
+            $currentPage.trigger("page.shown",currentPageName);
+    }
+
+    function app(pageName,param) {
+
+        var $page = $(document.body).find("section#" + pageName);
+
+        var src = $page.attr("src");
+        if( src && $page.find(">:first-child").length == 0) { // it has src and is empty
+            $.get(src, "html")
+                .done(function(html){$page.html(html); show(pageName,param); })
+                .fail(function(){ alert("failed to get:" + src); });
+        } else
+            show(pageName,param);
+    }
+
+    app.page = function(pageName, handler) {
+        pageHandlers[pageName] = handler;
+    }
+
+    function onhashchange()
+    {
+        var hash = location.hash || "#" + $("section[default]").attr('id');
+
+        var re = /#([-0-9A-Za-z]+)(\:(.+))?/;
+        var match = re.exec(hash);
+        hash = match[1];
+        var param = match[3];
+        app(hash,param);
+    }
+
+    $(window).on("hashchange", onhashchange );
+
+    window.app = app;
+
+    $(onhashchange); // call it for the initialization
 
 })(jQuery,this);
-
-
-
-
-
-

--- a/spapp.js
+++ b/spapp.js
@@ -1,80 +1,85 @@
 /**
- * @author Andrew Fedoniouk <andrew@terrainformatica.com>
- * @name jQuery Single Page Application micro framework
- * @license MIT
- * @purpose routing and dynamic content on single page web applications
- */
+* @author Andrew Fedoniouk <andrew@terrainformatica.com>
+* @name jQuery Single Page Application micro framework
+* @license MIT
+* @purpose routing and dynamic content on single page web applications
+*/
 
 
 (function($,window){
 
-    var pageHandlers = {};
+  var pageHandlers = {};
 
-    var currentPageName = null;
-    var $currentPage = null;
+  var currentPageName = null;
+  var $currentPage = null;
 
-    function show(pageName,param) {
-        var $page = $("section#" + pageName);
-        if( $page.length == 0 ) {
-            console.warn("section with id=%s not found!",pageName);
-            return;
-        }
-        var ph = pageHandlers[pageName];
-        if( ph ) {
-            var that = $page.length > 0 ? $page[0] : null;
-
-            var r = ph.call(that , param);
-            if( typeof r == "function" ) { // it returns the function that's used for view rendering
-                if(!($page.attr("no-ctl-cache") == ""))
-                    pageHandlers[pageName] = r;
-                r.call(that, param); // call that rendering function
-            }
-        }
-        if(currentPageName) { // "close" current page view
-            $(document.body).removeClass(currentPageName); // remove old page class {
-            if($currentPage) {
-                $currentPage.trigger("page.hidden",currentPageName);
-                if($currentPage.attr('src') && $currentPage.attr("no-ctl-cache"))
-                    $currentPage.empty();
-            }
-        }
-        $(document.body).addClass(currentPageName = pageName); // set new page class
-        if($currentPage = $page)
-            $currentPage.trigger("page.shown",currentPageName);
+  function show(pageName,param) {
+    var $page = $("section#" + pageName);
+    if( $page.length == 0 ) {
+      console.warn("section with id=%s not found!",pageName);
+      return;
     }
-
-    function app(pageName,param) {
-
-        var $page = $(document.body).find("section#" + pageName);
-
-        var src = $page.attr("src");
-        if( src && $page.find(">:first-child").length == 0) { // it has src and is empty
-            $.get(src, "html")
-                .done(function(html){$page.html(html); show(pageName,param); })
-                .fail(function(){ alert("failed to get:" + src); });
-        } else
-            show(pageName,param);
+    var ph = pageHandlers[pageName];
+    if( ph ) {
+      var that = $page.length > 0 ? $page[0] : null;
+      var r = ph.call(that , param);
+      if( typeof r == "function" ) { // it returns the function that's used for view rendering
+        if(!($page.attr("no-ctl-cache") == ""))
+            pageHandlers[pageName] = r;
+        r.call(that, param); // call that rendering function
+      }
     }
-
-    app.page = function(pageName, handler) {
-        pageHandlers[pageName] = handler;
+    if(currentPageName) { // "close" current page view
+      $(document.body).removeClass(currentPageName); // remove old page class {
+      if($currentPage) {
+        $currentPage.trigger("page.hidden",currentPageName);
+        if($currentPage.attr('src') && $currentPage.attr("no-ctl-cache"))
+            $currentPage.empty();
+      }
     }
+    $(document.body).addClass(currentPageName = pageName); // set new page class
+    if($currentPage = $page)
+      $currentPage.trigger("page.shown",currentPageName);
+  }
 
-    function onhashchange()
-    {
-        var hash = location.hash || "#" + $("section[default]").attr('id');
+  function app(pageName,param) {
 
-        var re = /#([-0-9A-Za-z]+)(\:(.+))?/;
-        var match = re.exec(hash);
-        hash = match[1];
-        var param = match[3];
-        app(hash,param);
-    }
+    var $page = $(document.body).find("section#" + pageName);
 
-    $(window).on("hashchange", onhashchange );
+    var src = $page.attr("src");
+    if( src && $page.find(">:first-child").length == 0) { // it has src and is empty
+      $.get(src, "html")
+          .done(function(html){$page.html(html); show(pageName,param); })
+          .fail(function(){ alert("failed to get:" + src); });
+    } else
+      show(pageName,param);
+  }
 
-    window.app = app;
+  app.page = function(pageName, handler) {
+    pageHandlers[pageName] = handler;
+  }
 
-    $(onhashchange); // call it for the initialization
+  function onhashchange()
+  {
+    var hash = location.hash || "#" + $("section[default]").attr('id');
+
+    var re = /#([-0-9A-Za-z]+)(\:(.+))?/;
+    var match = re.exec(hash);
+    hash = match[1];
+    var param = match[3];
+    app(hash,param);
+  }
+
+  $(window).on("hashchange", onhashchange );
+
+  window.app = app;
+
+  $(onhashchange); // call it for the initialization
 
 })(jQuery,this);
+
+
+
+
+
+


### PR DESCRIPTION
Sry, the changes at the README.md are out of scope. But I missed it to change the readme and add the 'default' attribute to the sample code.  

Also i run in trouble by using spapp with many objects in the sections. After leaving a section some times the application slows down. I solved this by clearing the sections content after leaving. Sections without a 'src' attribute will be ignored. 
