### PR TITLE
New event handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,14 +114,42 @@ The application can be switched to show different views in one of these ways:
 
 In all cases the SPApp framework will call controller registered for the view passing given parameter to it.
 
-## View events
+## Events
+When the browser transitions between views, several events are triggered at critical points:
 
-While switching the view the SPAapp will trigger two events:
+- `page.hidden: function(currentPageName)`: triggered on the current `<section>` before it is replaced by the new one.
+- `page.loadStarted: function(url)`: triggered before an ajax call is made to load `<section>` contents.
+- `page.loadSucceeded: function(jqXHR)`: triggered after the ajax call finishes successfully but before the new `<section>` is rendered.
+- `page.loadFailed: function(jqXHR,textStatus,errorThrown)`: triggered after the ajax call fails (for example, because of a non-200 response status).
+- `page.loadFinished: function(jqXHR,textStatus,errorThrown)`: always triggered after the ajax call, regardless of whether it succeeded.
+- `page.shown: function(currentPageName)`: triggered right before the new `<section>` is displayed.
 
- 1. "page.hidden" with `event.target` set on `<section>` to be "closed" and
- 2. "page.shown" with `event.target` set on `<section>` to be "shown".
-  
- So by subscribing on these events any code inside or outside controllers can receive notification about application state change.
+Note that when an ajax call is made, **3** events will be triggered:
+
+1. `page.loadStarted`
+2. `page.loadSucceeded` or `page.loadFailed`, depending on whether the ajax call succeeded
+3. `page.loadFinished`
+
+To set an event handler, call `$.on()` for the `<section>`(s) that you want to modify.
+
+Example:
+
+```
+// Configure event handlers for all <section>s
+$('section')
+  .on('page.loadStarted', function(url) {
+    // Show a "loading..." modal before each ajax request.
+    $('#loading-modal').show();
+  })
+  .on('page.loadFailed', function(jqXHR,textStatus,errorThrown) {
+    // Let the user know that something bad just happened.
+    alert('Failed to load page. Check network tab in console for more information.');
+  })
+  .on('page.loadFinished', function(jqXHR,textStatus,errorThrown) {
+    // Hide the "loading..." modal.
+    $('#loading-modal').hide();
+  });
+```
 
 ## Styling application and view states.
 

--- a/README.md
+++ b/README.md
@@ -117,12 +117,12 @@ In all cases the SPApp framework will call controller registered for the view pa
 ## Events
 When the browser transitions between views, several events are triggered at critical points:
 
-- `page.hidden: function(currentPageName)`: triggered on the current `<section>` before it is replaced by the new one.
-- `page.loadStarted: function(url)`: triggered before an ajax call is made to load `<section>` contents.
-- `page.loadSucceeded: function(jqXHR)`: triggered after the ajax call finishes successfully but before the new `<section>` is rendered.
-- `page.loadFailed: function(jqXHR,textStatus,errorThrown)`: triggered after the ajax call fails (for example, because of a non-200 response status).
-- `page.loadFinished: function(jqXHR,textStatus,errorThrown)`: always triggered after the ajax call, regardless of whether it succeeded.
-- `page.shown: function(currentPageName)`: triggered right before the new `<section>` is displayed.
+- `page.hidden: function(event,currentPageName)`: triggered on the current `<section>` before it is replaced by the new one.
+- `page.loadStarted: function(event,url)`: triggered before an ajax call is made to load `<section>` contents.
+- `page.loadSucceeded: function(event,jqXHR)`: triggered after the ajax call finishes successfully but before the new `<section>` is rendered.
+- `page.loadFailed: function(event,jqXHR,textStatus,errorThrown)`: triggered after the ajax call fails (for example, because of a non-200 response status).
+- `page.loadFinished: function(event,jqXHR,textStatus,errorThrown)`: always triggered after the ajax call, regardless of whether it succeeded.
+- `page.shown: function(event,currentPageName)`: triggered right before the new `<section>` is displayed.
 
 Note that when an ajax call is made, **3** events will be triggered:
 
@@ -137,15 +137,15 @@ Example:
 ```
 // Configure event handlers for all <section>s
 $('section')
-  .on('page.loadStarted', function(url) {
+  .on('page.loadStarted', function(event,url) {
     // Show a "loading..." modal before each ajax request.
     $('#loading-modal').show();
   })
-  .on('page.loadFailed', function(jqXHR,textStatus,errorThrown) {
+  .on('page.loadFailed', function(event,jqXHR,textStatus,errorThrown) {
     // Let the user know that something bad just happened.
     alert('Failed to load page. Check network tab in console for more information.');
   })
-  .on('page.loadFinished', function(jqXHR,textStatus,errorThrown) {
+  .on('page.loadFinished', function(event,jqXHR,textStatus,errorThrown) {
     // Hide the "loading..." modal.
     $('#loading-modal').hide();
   });

--- a/spapp.js
+++ b/spapp.js
@@ -48,16 +48,26 @@
 
     var src = $page.attr("src");
     if( src && $page.find(">:first-child").length == 0) { // it has src and is empty
+      $page.trigger("page.loadStarted",src);
       $.get(src, "html")
-          .done(function(html){$page.html(html); show(pageName,param); })
-          .fail(function(){ alert("failed to get:" + src); });
+          .done(function(html,textStatus,jqXHR){
+            $page.html(html);
+            $page.trigger("page.loadSucceeded",jqXHR);
+            show(pageName,param);
+          })
+          .fail(function(xhr,textStatus,errorThrown){
+            $page.trigger("page.loadFailed",xhr,textStatus,errorThrown);
+          })
+          .always(function(jqXHR,textStatus,errorThrown){
+            $page.trigger("page.loadFinished",jqXHR,textStatus,errorThrown)
+          });
     } else
       show(pageName,param);
   }
 
   app.page = function(pageName, handler) {
     pageHandlers[pageName] = handler;
-  }
+  };
 
   function onhashchange()
   {
@@ -77,9 +87,3 @@
   $(onhashchange); // call it for the initialization
 
 })(jQuery,this);
-
-
-
-
-
-

--- a/spapp.js
+++ b/spapp.js
@@ -55,8 +55,8 @@
             $page.trigger("page.loadSucceeded",jqXHR);
             show(pageName,param);
           })
-          .fail(function(xhr,textStatus,errorThrown){
-            $page.trigger("page.loadFailed",xhr,textStatus,errorThrown);
+          .fail(function(jqXHR,textStatus,errorThrown){
+            $page.trigger("page.loadFailed",jqXHR,textStatus,errorThrown);
           })
           .always(function(jqXHR,textStatus,errorThrown){
             $page.trigger("page.loadFinished",jqXHR,textStatus,errorThrown)


### PR DESCRIPTION
Added 4 new event handlers so that applications can plug into the ajax functionality:

- `page.loadStarted` triggered before the ajax call is made.
- `page.loadSucceeded` triggered after the ajax call succeeds but before the new view is shown.
- `page.loadFailed` triggered after the ajax call fails.
- `page.loadFinished` always triggered after the ajax call is finished, regardless of whether it succeeded.

Note:  This PR removes the default error handling when an ajax call fails (`alert("failed to get:" + src);`).